### PR TITLE
Add Flask dashboard for browsing broadcast schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # homeshoppingcrawling
-homeshoppingcrawling
+
+This project now includes a small Flask-based dashboard for exploring
+home shopping broadcast schedules stored in a SQLite database.
+
+## Dashboard
+
+`dashboard.py` starts a web server that queries the `schedules` table in
+`schedules.db` and renders the results as an HTML table at the
+`/dashboard` route. The endpoint accepts optional query parameters to
+filter the output:
+
+- `category` – product category to show
+- `channel` – broadcasting channel
+- `date` – broadcast date in `YYYY-MM-DD` format
+
+### Run
+
+Install the required dependency and start the server:
+
+```bash
+pip install flask
+python dashboard.py
+```
+
+Open [http://localhost:5000/dashboard](http://localhost:5000/dashboard)
+in a browser and append the desired query parameters, for example:
+
+```
+http://localhost:5000/dashboard?category=electronics&channel=HSTV&date=2023-09-01
+```
+
+The application expects a SQLite database file named `schedules.db` with
+a `schedules` table in the project root.

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,76 @@
+from flask import Flask, request, render_template_string
+import sqlite3
+from pathlib import Path
+from typing import List, Optional
+
+app = Flask(__name__)
+
+DATABASE_PATH = Path(__file__).parent / 'schedules.db'
+
+
+def get_schedules(
+    category: Optional[str] = None,
+    channel: Optional[str] = None,
+    date: Optional[str] = None,
+):
+    """Query schedules from SQLite DB with optional filters."""
+    if not DATABASE_PATH.exists():
+        return []
+    conn = sqlite3.connect(DATABASE_PATH)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    query = 'SELECT * FROM schedules WHERE 1=1'
+    params: List[str] = []
+    if category:
+        query += ' AND category = ?'
+        params.append(category)
+    if channel:
+        query += ' AND channel = ?'
+        params.append(channel)
+    if date:
+        query += ' AND date = ?'
+        params.append(date)
+    cur.execute(query, params)
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+@app.route('/dashboard')
+def dashboard():
+    category = request.args.get('category')
+    channel = request.args.get('channel')
+    date = request.args.get('date')
+    rows = get_schedules(category, channel, date)
+    columns = rows[0].keys() if rows else []
+    html = render_template_string(
+        """
+        <html>
+        <head><title>Broadcast Dashboard</title></head>
+        <body>
+            <h1>Broadcast Schedule</h1>
+            {% if rows %}
+            <table border="1" cellspacing="0" cellpadding="4">
+                <tr>
+                    {% for col in columns %}<th>{{ col }}</th>{% endfor %}
+                </tr>
+                {% for row in rows %}
+                <tr>
+                    {% for col in columns %}<td>{{ row[col] }}</td>{% endfor %}
+                </tr>
+                {% endfor %}
+            </table>
+            {% else %}
+            <p>No data found.</p>
+            {% endif %}
+        </body>
+        </html>
+        """,
+        rows=rows,
+        columns=columns,
+    )
+    return html
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- build `dashboard.py` Flask app with `/dashboard` endpoint querying a SQLite `schedules` table and optional category/channel/date filters
- document dashboard usage and startup instructions in README

## Testing
- `python -m py_compile dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68be677a360c83219caa0ec08b1d1cbc